### PR TITLE
実装完了、navigatorの画面遷移とフレーム生成後の処理追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/session_1/main_page.dart';
+import 'package:flutter_training/session_3/starting_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -10,6 +11,12 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(home: MainPage());
+    return MaterialApp(
+      routes: {
+        'splash_page': (context) => const StartingScreen(),
+        'weather_page': (context) => const MainRPage(),
+        },
+      initialRoute: 'splash_page',
+    );
   }
 }

--- a/lib/session_1/main_page.dart
+++ b/lib/session_1/main_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/session_1/weather_screen.dart';
 
-class MainPage extends StatelessWidget {
-  const MainPage({super.key});
+class MainRPage extends StatelessWidget {
+  const MainRPage({super.key});
 
   Widget buildView() {
     return const Scaffold(body: WeatherScreen());

--- a/lib/session_1/weather_screen.dart
+++ b/lib/session_1/weather_screen.dart
@@ -9,7 +9,25 @@ class WeatherScreen extends StatefulWidget {
   State<WeatherScreen> createState() => _WeatherScreenState();
 }
 
-class _WeatherScreenState extends State<WeatherScreen> {
+class _WeatherScreenState extends State<WeatherScreen>
+    with WidgetsBindingObserver {
+  // observe lifecycle
+  @override
+  void initState() {
+    super.initState();
+    print('i am in initStating...');
+    WidgetsBinding.instance.addObserver(this);
+  }
+  // observe lifecycle
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    print('I m in didChangeAppLifecycleState...');
+    super.didChangeAppLifecycleState(state);
+    // stateの値は以下のドキュメント参照
+    // https://docs.flutter.dev/get-started/flutter-for/uikit-devs#listening-to-lifecycle-events
+    print('the state now is is $state');
+  }
+
   // control the middle image
   Widget controlPlaceHolder = const Placeholder();
   @override
@@ -63,7 +81,11 @@ class _WeatherScreenState extends State<WeatherScreen> {
               children: [
                 Expanded(
                   child: TextButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      if (mounted) {
+                        Navigator.pop(context);
+                      }
+                    },
                     child: const Text('Close'),
                   ),
                 ),

--- a/lib/session_3/starting_screen.dart
+++ b/lib/session_3/starting_screen.dart
@@ -1,0 +1,30 @@
+// import 'dart:nativewrappers/_internal/vm/lib/developer.dart';
+
+import 'package:flutter/material.dart';
+
+class StartingScreen extends StatefulWidget {
+  const StartingScreen({super.key});
+
+  @override
+  State<StartingScreen> createState() => _StartingScreenState();
+}
+
+class _StartingScreenState extends State<StartingScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      Future.delayed(const Duration(milliseconds: 500), () {
+        if (mounted) {
+          Navigator.pushNamed(context, 'weather_page');
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(color: Colors.green);
+  }
+}


### PR DESCRIPTION
## 課題

close #3

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 画面遷移 -> Navigator
- widgetBinding.instance.endOfFrameの理解/実装とaddPostFrameCallbackの理解

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->